### PR TITLE
Fix bug where contrib graph cannot be found

### DIFF
--- a/lib/react-github-calendar.js
+++ b/lib/react-github-calendar.js
@@ -288,7 +288,7 @@ module.exports = function GitHubCalendar(container, username, options) {
         }).then(function (body) {
             var div = document.createElement("div");
             div.innerHTML = body;
-            var cal = div.querySelector(".js-contribution-graph");
+            var cal = div.querySelector(".graph-before-activity-overview");
             cal.querySelector(".float-left.text-gray").innerHTML = options.summary_text;
 
             // If 'include-fragment' with spinner img loads instead of the svg, fetchCalendar again


### PR DESCRIPTION
I think GitHub has renamed `.js-contribution-graph` with `.graph-before-activity-overview`, hence caused the graph not being fetched.